### PR TITLE
Support for canvas textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Unbinds gl variables and remove the canvas from the DOM.
     img.src = './texture.jpg'
 
     let shader = createShader({
+        dpr: window.devicePixelRatio || 1,
         canvas: document.querySelector('canvas'),
         uniforms: {
             map: {
@@ -115,7 +116,6 @@ Unbinds gl variables and remove the canvas from the DOM.
 ### TODO
 - mipmap filters
 - uniform type detection
-- DPI
 - better error log
 - renderer options (alpha, ...)
 - extensions (derivatives, ...)

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,12 +26,10 @@
 <body>
     <canvas></canvas>
     <canvas></canvas>
+    <canvas></canvas>
 
     <script type="module">
         import shader from '../index.js'
-
-        let img = new Image()
-        img.src = './image.jpg'
 
         let canvases = document.querySelectorAll('canvas')
 
@@ -43,14 +41,16 @@
         sd.start()
 
         // Use an image
-        let canvas2 = document.querySelectorAll('canvas')[1]
+        let img1 = new Image()
+        img1.src = './image.jpg'
+
         let sd2 = shader({
-            dpr: window.devicePixelRatio || 1,
+            dpr: window.devicePixelRatio,
             canvas: canvases[1],
             uniforms: {
                 map: {
                     type: 'sampler2D',
-                    value: img,
+                    value: img1,
                     wrapS: 'clamp',
                     flipY: true
                 }
@@ -78,6 +78,65 @@
         })
         sd2.resize(400, 400)
         sd2.start()
+
+        // Use a canvas element
+        let ctx = document.createElement('canvas').getContext('2d')
+        ctx.canvas.width = 400
+        ctx.canvas.height = 400
+        ctx.fillStyle = '#CCC'
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+
+        let sd3 = shader({
+            drp: window.devicePixelRatio,
+            canvas: canvases[2],
+            uniforms: {
+                canvas: {
+                    type: 'sampler2D',
+                    value: ctx.canvas,
+                    flipY: true
+                }
+            },
+            fragmentShader: `
+                precision highp float;
+                uniform vec2 resolution;
+                uniform sampler2D canvas;
+
+                void main() {
+                    vec2 st = gl_FragCoord.xy / resolution.xy;
+                    gl_FragColor = texture2D(canvas, st);
+                }
+            `
+        })
+        sd3.resize(ctx.canvas.width, ctx.canvas.height)
+        sd3.start()
+
+        function crop(img, width, height, alignX = 0.5, alignY = 0.5) {
+
+            const ratio = img.width / img.height
+            const rect = { x: 0, y: 0, width, height }
+
+            if (ratio > (width / height)) {
+                rect.width = img.width * (height / img.height)
+                rect.x = (width - rect.width) * alignX
+            } else {
+                rect.height = img.height * (width / img.width)
+                rect.y = (height - rect.height) * alignY
+            }
+
+            return rect
+        }
+
+        let img2 = new Image()
+        img2.crossOrigin = 'anonymous'
+        img2.src = 'https://source.unsplash.com/collection/981639/1024x576'
+
+        img2.onload = function() {
+            const img = this
+            const rect = crop(img, ctx.canvas.width, ctx.canvas.height)
+            ctx.drawImage(img, rect.x, rect.y, rect.width, rect.height)
+            sd3.uniforms.canvas.update()
+        };
+
     </script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ class Shader {
             if (uniform.value instanceof Image || uniform.value instanceof HTMLCanvasElement) {
                 uniform._isImage = true
                 uniform._value = new Texture(gl, uniform.value, uniform.wrapS, uniform.wrapT, uniform.filter, uniform.flipY)
+                uniform.update = () => uniform._value.update()
             }
             if (uniform._type.indexOf('Matrix') > -1) {
                 uniform._isMatrix = true

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class Shader {
             let uniform = this.uniforms[name]
             uniform._location = gl.getUniformLocation(program, name)
             uniform._type = getUniformType(uniform.type)
-            if (uniform.value instanceof Image) {
+            if (uniform.value instanceof Image || uniform.value instanceof HTMLCanvasElement) {
                 uniform._isImage = true
                 uniform._value = new Texture(gl, uniform.value, uniform.wrapS, uniform.wrapT, uniform.filter, uniform.flipY)
             }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.0",
   "description": "A native webgl wrapper for 2D shaders.",
   "main": "index.js",
-  "scripts": {
-    "start": "npx live-server --open=demo"
-  },
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ayamflow/standalone-shader.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "description": "A native webgl wrapper for 2D shaders.",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "start": "npx live-server --open=demo"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ayamflow/standalone-shader.git"

--- a/texture.js
+++ b/texture.js
@@ -32,11 +32,11 @@ export default class Texture {
             gl.bindTexture(gl.TEXTURE_2D, texture)
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]))
 
-            const onload = () => {
+            const self = this
+            image.addEventListener('onload', function onload() {
                 image.removeEventListener('load', onload)
-                this.update()
-            }
-            image.addEventListener('load', onload);
+                self.update()
+            })
         }
     }
 

--- a/texture.js
+++ b/texture.js
@@ -16,44 +16,53 @@ const FILTER = {
 export default class Texture {
     constructor(gl, image, wrapS, wrapT, filter, flipY) {
         const texture = gl.createTexture()
+        this.gl = gl
         this.texture = texture
+        this.image = image
+        this.flipY = flipY
+        this.wrapS = getProp(gl, WRAP, wrapS)
+        this.wrapT = getProp(gl, WRAP, wrapT)
+        this.filter = getProp(gl, FILTER, filter)
 
-        const ws = getProp(gl, WRAP, wrapS)
-        const wt = getProp(gl, WRAP, wrapT)
-        const f = getProp(gl, FILTER, filter)
-
-        if (image.complete && image.width && image.height) {
-            onImageReady(gl, texture, image, ws, wt, f, flipY)
+        if (image.complete && image.width && image.height || image instanceof Image === false) {
+            // Update if already loaded or not an image element
+            this.update()
         } else {
             // Fill texture with black pixel if image isn't ready
             gl.bindTexture(gl.TEXTURE_2D, texture)
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]))
-            image.onload = function() {
-                image.onload = null
-                onImageReady(gl, texture, image, ws, wt, f, flipY)
-            }
+
+            image.addEventListener('load', function onload() {
+                image.removeEventListener('load', onload)
+                this.update()
+            }.bind(this))
         }
+    }
+
+    update() {
+        const gl = this.gl
+        const image = this.image
+
+        gl.bindTexture(gl.TEXTURE_2D, this.texture)
+
+        if (this.flipY === true) {
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
+        }
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
+
+        if (isPowerOf2(image.width) && isPowerOf2(image.height)) {
+            gl.generateMipmap(gl.TEXTURE_2D)
+        }
+
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.wrapS || gl.CLAMP_TO_EDGE)
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this.wrapT || gl.CLAMP_TO_EDGE)
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.filter || gl.LINEAR)
     }
 
     destroy(gl) {
         gl.deleteTexture(this.texture)
     }
-}
-
-function onImageReady(gl, texture, image, wrapS, wrapT, filter, flipY) {
-    gl.bindTexture(gl.TEXTURE_2D, texture)
-    if (flipY === true) {
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    }
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
-
-    if (isPowerOf2(image.width) && isPowerOf2(image.height)) {
-        gl.generateMipmap(gl.TEXTURE_2D)
-    }
-
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS || gl.CLAMP_TO_EDGE)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT || gl.CLAMP_TO_EDGE)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter || gl.LINEAR)
 }
 
 function isPowerOf2(value) {

--- a/texture.js
+++ b/texture.js
@@ -32,10 +32,11 @@ export default class Texture {
             gl.bindTexture(gl.TEXTURE_2D, texture)
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]))
 
-            image.addEventListener('load', function onload() {
+            const onload = () => {
                 image.removeEventListener('load', onload)
                 this.update()
-            }.bind(this))
+            }
+            image.addEventListener('load', onload);
         }
     }
 
@@ -60,8 +61,8 @@ export default class Texture {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, this.filter || gl.LINEAR)
     }
 
-    destroy(gl) {
-        gl.deleteTexture(this.texture)
+    destroy() {
+        this.gl.deleteTexture(this.texture)
     }
 }
 


### PR DESCRIPTION
Promise I'm not going to bombard you with pull requests! This might require a little more review though, as I'm not sure if there's a better way to do this. 

I've added support for using an HTMLCanvasElement as a texture - essentially looking to replicate `background-size: cover` with an image, and the only way I've seen this done is using `drawImage` on a 2d canvas, and then using that as the sampler2D texture. The demo includes a third example with this technique.

Image uniforms now include an `update()` method on the top-level uniform that calls what was previously onImageReady.

Cheers!

_side note - looks like my previous PR commits came along for the ride. Pretty sure I pulled your merge and branched feature/canvas-textures off master though..._