### PR TITLE
Fixed texture addEventListener to use load vs onload

### DIFF
--- a/texture.js
+++ b/texture.js
@@ -33,7 +33,7 @@ export default class Texture {
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]))
 
             const self = this
-            image.addEventListener('onload', function onload() {
+            image.addEventListener('load', function onload() {
                 image.removeEventListener('load', onload)
                 self.update()
             })


### PR DESCRIPTION
Sorry about this. Easy to overlook when focusing on the canvas implementation while demo 2 was loading a local image. 